### PR TITLE
Fix type generator formatting

### DIFF
--- a/lib/kanji/templates/app/types/type.rb.tt
+++ b/lib/kanji/templates/app/types/type.rb.tt
@@ -5,9 +5,9 @@ module Types
     name "<%= config[:class_name] %>"
     description "Replace this description with something useful"
 
-  <% config[:attributes].each do |attribute| -%>
+<% config[:attributes].each do |attribute| -%>
     attribute :<%= attribute[0] %>, <%= config[:lookup_type].(attribute[1]) %>, "Replace this description"
-  <% end -%>
+<% end -%>
 
     register :repo, <%= config[:application_class] %>::Container["repos.<%= config[:pluralized_type_name] %>"]
 


### PR DESCRIPTION
When generating new types the generator is not formatting the fields
correctly by placing extra spaces as well as a line with blank spaces at
the end of the fields. This addresses those minor formatting issues.