### PR TITLE
Adds rake and bundler as development dependencies

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,3 @@
+require "bundler/gem_tasks"
+
 Dir.glob('lib/tasks/*.rake').each { |r| load r }

--- a/kanji.gemspec
+++ b/kanji.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency "tilt", "~> 2.0"
   s.add_dependency "transproc", "~> 1.0"
 
+  s.add_development_dependency "bundler", "~> 1.15"
   s.add_development_dependency "byebug", "~> 9.0"
   s.add_development_dependency "coveralls", "~> 0.8"
   s.add_development_dependency "pry-byebug", "~> 3.4"


### PR DESCRIPTION
Also adds the bundler gem rake tasks to the Rakefile. This makes things
like `rake release` available to help with publishing and tagging.