### PR TITLE
Ensure migrate folder exists on new app

### DIFF
--- a/lib/kanji/generators/project.rb
+++ b/lib/kanji/generators/project.rb
@@ -88,6 +88,7 @@ start exploring!
       def add_db
         add_template("db/sample_data.rb", "db/sample_data.rb")
         add_template("db/seed.rb", "db/seed.rb")
+        add_template(".keep", "db/migrate/.keep")
       end
 
       def add_app


### PR DESCRIPTION
Currently we are throwing an error if you run rake db:migrate.

Errno::ENOENT: No such file or directory @ dir_initialize - db/migrate

This error can be handled by always having a migrate folder when you run
create a new app.


-------
Unfortunately this runs us into another error, but is out of our control currently. 

https://github.com/jeremyevans/sequel/issues/1417