### PR TITLE
Fixes issue with dashes in the app name

### DIFF
--- a/lib/kanji/generators/project.rb
+++ b/lib/kanji/generators/project.rb
@@ -72,7 +72,7 @@ start exploring!
       end
 
       def camel_cased_app_name
-        Dry::Core::Inflector.camelize(app_name)
+        Dry::Core::Inflector.camelize(underscored_project_name)
       end
 
       def add_bin


### PR DESCRIPTION
This was not converting names with dashes to appropriate camel cased
names.

Fixes #2 